### PR TITLE
자정에 담배를 피지 않은 사람들의 통계 업데이트

### DIFF
--- a/src/main/java/thisiscomedy/nodamnodam/server/ServerApplication.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/ServerApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @ConfigurationPropertiesScan
 @EnableFeignClients
+@EnableScheduling
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeGetService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeGetService.java
@@ -27,7 +27,13 @@ public class SmokeGetService {
 
     public SmokeCauseResponse getCauseStats() {
         User user = userGetService.getUser();
-        return smokeRepository.getSmokeCauseStats(user).get(0);
+        List<SmokeCauseResponse> smokeCauseResponseList = smokeRepository.getSmokeCauseStats(user);
+
+        if (smokeCauseResponseList.isEmpty()) {
+            return null;
+        }
+
+        return smokeCauseResponseList.get(0);
     }
 
     public boolean isSmokedToday(User user) {

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeGetService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeGetService.java
@@ -29,4 +29,8 @@ public class SmokeGetService {
         User user = userGetService.getUser();
         return smokeRepository.getSmokeCauseStats(user).get(0);
     }
+
+    public boolean isSmokedToday(User user) {
+        return smokeRepository.existsByUser(user);
+    }
 }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeSaveService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeSaveService.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Service;
 import thisiscomedy.nodamnodam.server.domain.smoke.exception.AlreadyPressFailButton;
 import thisiscomedy.nodamnodam.server.domain.smoke.presentation.dto.request.SmokeRequest;
 import thisiscomedy.nodamnodam.server.domain.smoke.repository.SmokeRepository;
+import thisiscomedy.nodamnodam.server.domain.stats.application.StatsGetService;
+import thisiscomedy.nodamnodam.server.domain.stats.application.StatsUpdateService;
 import thisiscomedy.nodamnodam.server.domain.user.application.UserGetService;
 import thisiscomedy.nodamnodam.server.domain.user.application.UserSaveService;
 import thisiscomedy.nodamnodam.server.domain.user.domain.User;
@@ -19,6 +21,8 @@ public class SmokeSaveService {
     private final SmokeRepository smokeRepository;
     private final UserGetService userGetService;
     private final UserSaveService userSaveService;
+    private final StatsGetService statsGetService;
+    private final StatsUpdateService statsUpdateService;
 
     public Long execute(SmokeRequest request) {
         User user = userGetService.getUser();
@@ -31,6 +35,8 @@ public class SmokeSaveService {
         }
 
         userSaveService.updateNoSmokeStartAt(user);
+
+        statsUpdateService.updateSmokeCount(statsGetService.getStats(user));
 
         return smokeRepository.save(request.toEntity(user)).getId();
     }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeSaveService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/application/SmokeSaveService.java
@@ -36,7 +36,7 @@ public class SmokeSaveService {
 
         userSaveService.updateNoSmokeStartAt(user);
 
-        statsUpdateService.updateSmokeCount(statsGetService.getStats(user));
+        statsUpdateService.updateWhenSmoke(statsGetService.getStats(user));
 
         return smokeRepository.save(request.toEntity(user)).getId();
     }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/repository/SmokeRepository.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/smoke/repository/SmokeRepository.java
@@ -18,6 +18,8 @@ public interface SmokeRepository extends JpaRepository<Smoke, Long> {
 
     boolean existsByCreatedAt(LocalDate date);
 
+    boolean existsByUser(User user);
+
     @Query(value = """
         select new thisiscomedy.nodamnodam.server.domain.smoke.presentation.dto.response.SmokeCauseResponse(
             s1.moment, s1.count,

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsGetService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsGetService.java
@@ -7,6 +7,7 @@ import thisiscomedy.nodamnodam.server.domain.rank.presentation.dto.response.Rank
 import thisiscomedy.nodamnodam.server.domain.smoke.application.SmokeGetService;
 import thisiscomedy.nodamnodam.server.domain.smoke.presentation.dto.response.GrassGetResponse;
 import thisiscomedy.nodamnodam.server.domain.smoke.presentation.dto.response.SmokeCauseResponse;
+import thisiscomedy.nodamnodam.server.domain.stats.domain.Stats;
 import thisiscomedy.nodamnodam.server.domain.stats.presentation.dto.response.StatsGetBadgeResponse;
 import thisiscomedy.nodamnodam.server.domain.stats.presentation.dto.response.StatsGetDetailsResponse;
 import thisiscomedy.nodamnodam.server.domain.stats.presentation.dto.response.StatsGetSummaryResponse;
@@ -59,5 +60,10 @@ public class StatsGetService {
 
     public List<RankResponse> getRank() {
         return statsRepository.getRank(PageRequest.of(0, 50));
+    }
+
+    public Stats getStats(User user) {
+        return statsRepository.findByUser(user)
+                .orElse(null);
     }
 }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsUpdateService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsUpdateService.java
@@ -1,10 +1,14 @@
 package thisiscomedy.nodamnodam.server.domain.stats.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import thisiscomedy.nodamnodam.server.domain.smoke.application.SmokeGetService;
 import thisiscomedy.nodamnodam.server.domain.stats.domain.Stats;
 import thisiscomedy.nodamnodam.server.domain.stats.repository.StatsRepository;
+import thisiscomedy.nodamnodam.server.domain.user.domain.User;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,7 +17,21 @@ public class StatsUpdateService {
     private final StatsRepository statsRepository;
     private final SmokeGetService smokeGetService;
 
-    public void updateSmokeCount(Stats stats) {
-        statsRepository.save(stats.updateSmokeCount());
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateStatsScheduling() {
+        List<Stats> statsList = statsRepository.findAll();
+        statsList.forEach(stats -> {
+            User user = stats.getUser();
+
+            if (smokeGetService.isSmokedToday(user)) {
+                return;
+            }
+
+            statsRepository.save(stats.updateByScheduling());
+        });
+    }
+
+    public void updateWhenSmoke(Stats stats) {
+        statsRepository.save(stats.updateWhenSmoke());
     }
 }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsUpdateService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/application/StatsUpdateService.java
@@ -1,0 +1,19 @@
+package thisiscomedy.nodamnodam.server.domain.stats.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import thisiscomedy.nodamnodam.server.domain.smoke.application.SmokeGetService;
+import thisiscomedy.nodamnodam.server.domain.stats.domain.Stats;
+import thisiscomedy.nodamnodam.server.domain.stats.repository.StatsRepository;
+
+@Service
+@RequiredArgsConstructor
+public class StatsUpdateService {
+
+    private final StatsRepository statsRepository;
+    private final SmokeGetService smokeGetService;
+
+    public void updateSmokeCount(Stats stats) {
+        statsRepository.save(stats.updateSmokeCount());
+    }
+}

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/domain/Stats.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/domain/Stats.java
@@ -48,4 +48,9 @@ public class Stats extends BaseTimeEntity {
         this.threeDayContinuityNoSmoke = threeDayContinuityNoSmoke;
         this.smokeCount = smokeCount;
     }
+
+    public Stats updateSmokeCount() {
+        this.smokeCount += 1;
+        return this;
+    }
 }

--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/domain/Stats.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/stats/domain/Stats.java
@@ -7,6 +7,11 @@ import lombok.NoArgsConstructor;
 import thisiscomedy.nodamnodam.server.domain.user.domain.User;
 import thisiscomedy.nodamnodam.server.global.entity.BaseTimeEntity;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -49,8 +54,24 @@ public class Stats extends BaseTimeEntity {
         this.smokeCount = smokeCount;
     }
 
-    public Stats updateSmokeCount() {
+    public Stats updateByScheduling() {
+        noSmokeDay += 1;
+        saveMoney += user.getCigarettePrice();
+        currentContinuityNoSmoke += 1;
+        maximumContinuityNoSmoke += 1;
+
+        LocalDate userNoSmokeStartAt = user.getNoSmokeStartAt();
+        LocalDate currentDate = new Date().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+
+        threeDayContinuityNoSmoke = Math.abs(Math.toIntExact(ChronoUnit.DAYS.between(currentDate, userNoSmokeStartAt))) / 3;
+
+        return this;
+    }
+
+    public Stats updateWhenSmoke() {
         this.smokeCount += 1;
+        this.currentContinuityNoSmoke = 0;
+        this.threeDayContinuityNoSmoke = 0;
         return this;
     }
 }


### PR DESCRIPTION
## 요약
자정에 담배를 피지 않은 사람들의 통계 업데이트

## 작업 내용
- 실패 버튼 눌렀을 때 통계에 smokeCount가 올라가던 점 수정
- 자정에 담배를 피지 않은 사람들의 통계 업데이트
- 금연 실패 이유 통계 가져올 때 데이터가 없을 경우 예외 처리