### PR TITLE
새로운 액세스 토큰 발급해줄 때 서로 다른 토큰이 저장되고 응답 데이터로 넘어 가는 점 수정

### DIFF
--- a/src/main/java/thisiscomedy/nodamnodam/server/domain/auth/application/AccessTokenReissueService.java
+++ b/src/main/java/thisiscomedy/nodamnodam/server/domain/auth/application/AccessTokenReissueService.java
@@ -22,13 +22,13 @@ public class AccessTokenReissueService {
     public TokenResponse execute(HttpServletRequest request) {
         try {
             String refreshToken = request.getHeader("Authorization-refresh").split(" ")[1].trim();
-
             String userId = SecurityContextHolder.getContext().getAuthentication().getName();
+            String newAccessToken = jwtProvider.createAccessToken(Long.valueOf(userId));
 
-            refreshTokenUpdateService.execute(refreshToken, jwtProvider.createAccessToken(Long.valueOf(userId)));
+            refreshTokenUpdateService.execute(refreshToken, newAccessToken);
 
             return new TokenResponse(
-                    jwtProvider.createAccessToken(Long.valueOf(userId)),
+                    newAccessToken,
                     refreshToken
             );
         } catch (NullPointerException e) {


### PR DESCRIPTION
## 요약
새로운 액세스 토큰 발급해줄 때 서로 다른 토큰이 저장되는 점 수정

## 작업 내용
- 새로운 액세스 토큰 발급해줄 때 서로 다른 토큰이 저장되고 응답 데이터로 넘어오는 로직 오류 수정